### PR TITLE
README: Clarify installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ To run the example module run ``make example``.
 
 To build the (very) limited documentation run ``make doc``.
 
+After the module is compiled with ``make``, insert getopt into the Erlang lib directory (e.g. by soft link or copying).
+
+```sh
+ln -s . /usr/local/lib/erlang/lib/getopt-0.7.1
+```
+
 
 Usage
 -----


### PR DESCRIPTION
After compiling, user is instructed to copy module into Erlang lib directory.
