### PR TITLE
FIX format_error : supporting options without the hyphen

### DIFF
--- a/src/getopt.erl
+++ b/src/getopt.erl
@@ -149,8 +149,13 @@ parse(OptSpecList, OptAcc, ArgAcc, _ArgPos, []) ->
 format_error(OptSpecList, {error, Reason}) ->
     format_error(OptSpecList, Reason);
 format_error(OptSpecList, {missing_required_option, Name}) ->
-    {_Name, Short, Long, _Type, _Help} = lists:keyfind(Name, 1, OptSpecList),
-    lists:flatten(["missing required option: -", [Short], " (", to_string(Long), ")"]);
+    OptStr = case lists:keyfind(Name, 1, OptSpecList) of
+                 {Name,  undefined, undefined, _Type, _Help} -> ["<", to_string(Name), ">"];
+                 {_Name, undefined,      Long, _Type, _Help} -> ["--", Long];
+                 {_Name,     Short, undefined, _Type, _Help} -> ["-", Short];
+                 {_Name,     Short,      Long, _Type, _Help} -> ["-", Short, " (", Long, ")"]
+             end,
+    lists:flatten(["missing required option: ", OptStr]);
 format_error(_OptSpecList, {invalid_option, OptStr}) ->
     lists:flatten(["invalid option: ", to_string(OptStr)]);
 format_error(_OptSpecList, {invalid_option_arg, {Name, Arg}}) ->

--- a/test/getopt_test.erl
+++ b/test/getopt_test.erl
@@ -287,7 +287,10 @@ tokenize_test_() ->
 check_test_() ->
     OptSpecList =
         [
-         {arg,        $a,        "arg",        string,   "Required arg"}
+         {  arg,        $a,     "arg",   string,   "Required arg"},
+         {short,        $s, undefined,   string,   "short option"},
+         { long, undefined,    "long",   string,   "long option"},
+         {other, undefined, undefined,   string,   "task"}
         ],
     {ok, {Opts, _}} = parse(OptSpecList, ""),
     [
@@ -301,6 +304,15 @@ check_test_() ->
      {"Format missing option error test 2",
       ?_assertEqual("missing required option: -a (arg)",
                     format_error(OptSpecList, {missing_required_option, arg}))},
+     {"Format missing option error test 3",
+      ?_assertEqual("missing required option: -s",
+                    format_error(OptSpecList, {missing_required_option, short}))},
+     {"Format missing option error test 4",
+      ?_assertEqual("missing required option: --long",
+                    format_error(OptSpecList, {missing_required_option, long}))},
+     {"Format missing option error test 5",
+      ?_assertEqual("missing required option: <other>",
+                    format_error(OptSpecList, {missing_required_option, other}))},
      {"Format invalid option error test 1",
       ?_assertEqual("invalid option: --verbose",
                     format_error(OptSpecList, {error, {invalid_option, "--verbose"}}))},


### PR DESCRIPTION
```erlang
{task, undefined, undefined,   string,   "task"}
```

If short is undefined, format_error is crashed.
This pull request is fix this.