### PR TITLE
Format "missing option argument" error

### DIFF
--- a/src/getopt.erl
+++ b/src/getopt.erl
@@ -149,12 +149,7 @@ parse(OptSpecList, OptAcc, ArgAcc, _ArgPos, []) ->
 format_error(OptSpecList, {error, Reason}) ->
     format_error(OptSpecList, Reason);
 format_error(OptSpecList, {missing_required_option, Name}) ->
-    OptStr = case lists:keyfind(Name, 1, OptSpecList) of
-                 {Name,  undefined, undefined, _Type, _Help} -> ["<", to_string(Name), ">"];
-                 {_Name, undefined,      Long, _Type, _Help} -> ["--", Long];
-                 {_Name,     Short, undefined, _Type, _Help} -> ["-", Short];
-                 {_Name,     Short,      Long, _Type, _Help} -> ["-", Short, " (", Long, ")"]
-             end,
+    OptStr = opt_to_list(lists:keyfind(Name, 1, OptSpecList)),
     lists:flatten(["missing required option: ", OptStr]);
 format_error(_OptSpecList, {invalid_option, OptStr}) ->
     lists:flatten(["invalid option: ", to_string(OptStr)]);
@@ -162,8 +157,20 @@ format_error(_OptSpecList, {invalid_option_arg, {Name, Arg}}) ->
     lists:flatten(["option \'", to_string(Name) ++ "\' has invalid argument: ", to_string(Arg)]);
 format_error(_OptSpecList, {invalid_option_arg, OptStr}) ->
     lists:flatten(["invalid option argument: ", to_string(OptStr)]);
+format_error(OptSpecList, {missing_option_arg, Name}) ->
+    OptStr = opt_to_list(lists:keyfind(Name, 1, OptSpecList)),
+    lists:flatten(["missing option argument: ", OptStr, " <", to_string(Name), $>]);
 format_error(_OptSpecList, {Reason, Data}) ->
     lists:flatten([to_string(Reason), " ", to_string(Data)]).
+
+opt_to_list({Name, undefined, undefined, _Type, _Help}) ->
+    [$<, to_string(Name), $>];
+opt_to_list({_Name, undefined, Long, _Type, _Help}) ->
+    [$-, $-, Long];
+opt_to_list({_Name, Short, undefined, _Type, _Help}) ->
+    [$-, Short];
+opt_to_list({_Name, Short, Long, _Type, _Help}) ->
+    [$-, Short, $\s, $(, Long, $)].
 
 
 %% @doc Parse a long option, add it to the option accumulator and continue

--- a/test/getopt_test.erl
+++ b/test/getopt_test.erl
@@ -298,6 +298,19 @@ check_test_() ->
       ?_assertEqual({error, {missing_required_option, arg}}, check(OptSpecList, Opts))},
      {"Parse arguments and check required options",
       ?_assertEqual({error, {missing_required_option, arg}}, parse_and_check(OptSpecList, ""))},
+    {"Parse arguments and check required option args",
+      ?_assertEqual({error, {missing_option_arg, arg}},
+                    parse_and_check(OptSpecList, "-a"))}].
+
+format_error_test_() ->
+    OptSpecList =
+        [
+         {   arg,        $a,     "arg",   string,   "Required arg"},
+         { short,        $s, undefined,   string,   "short option"},
+         {  long, undefined,    "long",   string,   "long option"},
+         { other, undefined, undefined,   string,   "task"}
+        ],
+    [
      {"Format missing option error test 1",
       ?_assertEqual("missing required option: -a (arg)",
                     format_error(OptSpecList, {error, {missing_required_option, arg}}))},
@@ -321,7 +334,21 @@ check_test_() ->
                     format_error(OptSpecList, {error, {invalid_option_arg, "arg_value"}}))},
      {"Format invalid option argument error test 2",
       ?_assertEqual("option 'verbose' has invalid argument: 100",
-                    format_error(OptSpecList, {error, {invalid_option_arg, {verbose, "100"}}}))}
+                    format_error(OptSpecList, {error, {invalid_option_arg, {verbose, "100"}}}))},
+     {"Format missing option argument error test 1",
+      ?_assertEqual("missing option argument: -a (arg) <arg>",
+                    format_error(OptSpecList, {error, {missing_option_arg, arg}}))},
+     {"Format missing option argument error test 2",
+      ?_assertEqual("missing option argument: -a (arg) <arg>",
+                    format_error(OptSpecList, {missing_option_arg, arg}))},
+     {"Format missing option argument error test 3",
+      ?_assertEqual("missing option argument: -s <short>",
+                    format_error(OptSpecList, {missing_option_arg, short}))},
+     {"Format missing option argument error test 4",
+      ?_assertEqual("missing option argument: --long <long>",
+                    format_error(OptSpecList, {missing_option_arg, long}))},
+     {"Format missing option argument error test 5",
+      ?_assertError(_, format_error(OptSpecList, {missing_option_arg, unknown}))}
     ].
 
 utf8_binary_test_() ->


### PR DESCRIPTION
It seems like `missing_option_arg` was the only expected error which isn't specially formatted by `format_error/2`.