### PR TITLE
Use the standard 3-clause BSD license text

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,19 +1,18 @@
-Copyright (c) 2009 Juan Jose Comellas
-All rights reserved.
+Copyright 2009 Juan Jose Comellas
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-  - Redistributions of source code must retain the above copyright notice, this
-    list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
 
-  - Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
 
-  - Neither the name of Juan Jose Comellas nor the names of its contributors may
-    be used to endorse or promote products derived from this software without
-    specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED


### PR DESCRIPTION
I copied the text from here:

https://opensource.org/licenses/BSD-3-Clause

This resolves an issue we are having with getting RabbitMQ dependency
licenses discovered by the "LicenseFinder" tool:

https://github.com/pivotal/LicenseFinder/issues/768