### PR TITLE
Fix tests for Erlang < 20

### DIFF
--- a/test/getopt_test.erl
+++ b/test/getopt_test.erl
@@ -357,6 +357,7 @@ utf8_binary_test_() ->
   Utf8 = unicode:characters_to_binary(Unicode),
   io:setopts(standard_error, [{encoding, utf8}]),
   OptSpecsWithDefault = [{utf8, undefined, "utf8", {utf8_binary, Utf8}, "UTF-8 arg"}],
+  UsageBin = unicode:characters_to_binary(getopt:usage_options(OptSpecsWithDefault)),
   [{"Empty utf8_binary argument",
     ?_assertEqual({ok, {[{utf8, <<>>}], []}}, parse(OptSpecList, ["--utf8", ""]))},
    {"Non empty utf8_binary argument",
@@ -364,4 +365,4 @@ utf8_binary_test_() ->
    {"Default utf8_binary argument",
     ?_assertEqual({ok, {[{utf8, Utf8}], []}}, parse(OptSpecsWithDefault, []))},
    {"Default utf8_binary argument usage",
-    ?_assert(is_list(string:find(getopt:usage_options(OptSpecsWithDefault), Unicode)))}].
+    ?_assertEqual(1, length(binary:matches(UsageBin, Utf8)))}].


### PR DESCRIPTION
The pull request fixes issue #48.

I tested with Erlang 17.5 and 18.3. I didn't test it with Erlang <17 because the official docker images are only available for Erlang 17 and higher.

It would be helpful if someone could test it with Erlang 13-16. In another case, the version range in README must be also changed to 17+.