### PR TITLE
rebar.config: make edoc preprocess

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,8 @@
             {platform_define, "^2", unicode_str}
 ]}.
 
+{edoc_opts, [preprocess]}.
+
 {dialyzer,
  [
   {warnings, [no_return, no_undefined_callbacks, no_unused]},


### PR DESCRIPTION
otherwise, edoc errored out on `-spec line_length() -> 0..?LINE_LENGTH.` and friends