### PR TITLE
Zomp

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2009 Juan Jose Comellas
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/zomp.meta
+++ b/zomp.meta
@@ -11,7 +11,7 @@
 {name,"Erlang GetOpt"}.
 {package_id,{"otpr","getopt",{1,0,2}}}.
 {prefix,none}.
-{repo_url,"https://github.com/zxq9/getopt"}.
+{repo_url,"https://github.com/jcomellas/getopt"}.
 {tags,["args","parsing","getopt","cli"]}.
 {type,lib}.
 {ws_url,[]}.

--- a/zomp.meta
+++ b/zomp.meta
@@ -1,0 +1,17 @@
+{a_email,[]}.
+{author,"Juan Jose Comellas"}.
+{c_email,[]}.
+{copyright,"Juan Jose Comellas"}.
+{deps,[]}.
+{desc,"A getopt utility for Erlang"}.
+{file_exts,[]}.
+{key_name,none}.
+{license,"BSD-3-Clause-Attribution"}.
+{modules,[]}.
+{name,"Erlang GetOpt"}.
+{package_id,{"otpr","getopt",{1,0,2}}}.
+{prefix,none}.
+{repo_url,"https://github.com/zxq9/getopt"}.
+{tags,["args","parsing","getopt","cli"]}.
+{type,lib}.
+{ws_url,[]}.


### PR DESCRIPTION
This adds the metadata necessary for use with the dynamic Erlang launcher ZX.
Added:
 - ebin/getopt.app (overwritten by rebar)
 - zomp.meta