### PR TITLE
getopt: remove duplicate annotation type

### DIFF
--- a/src/getopt.erl
+++ b/src/getopt.erl
@@ -144,8 +144,10 @@ parse(OptSpecList, OptAcc, ArgAcc, _ArgPos, []) ->
 
 
 %% @doc Format the error code returned by prior call to parse/2 or check/2.
--spec format_error([option_spec()], {error, {Reason :: atom(), Data :: term()}} |
-                   {Reason :: term(), Data :: term()}) -> string().
+-spec format_error([option_spec()], {error, {Reason, Data}} |
+                   {Reason, Data}) -> string() when
+      Reason :: term(),
+      Data :: term().
 format_error(OptSpecList, {error, Reason}) ->
     format_error(OptSpecList, Reason);
 format_error(OptSpecList, {missing_required_option, Name}) ->


### PR DESCRIPTION
as per OTP pull request [#7717](https://github.com/erlang/otp/pull/7717), duplicate annotation types will not be allowed in OTP-27. 

this PR simply re-writes the type specification so that it is compliant with the OTP change.